### PR TITLE
Update URLS of the IPFS specs

### DIFF
--- a/include/ipfs/client.h
+++ b/include/ipfs/client.h
@@ -64,7 +64,7 @@ class Client {
   /** Return the identity of the peer.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/generic#id.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/MISCELLANEOUS.md#id.
    *
    * An example usage:
    * @snippet generic.cc ipfs::Client::Id
@@ -80,7 +80,7 @@ class Client {
   /** Return the implementation version of the peer.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/generic#version.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/MISCELLANEOUS.md#version.
    *
    * An example usage:
    * @snippet generic.cc ipfs::Client::Version
@@ -96,7 +96,7 @@ class Client {
   /** Query the current config of the peer.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/config#configget.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/CONFIG.md#configget.
    *
    * An example usage:
    * @snippet config.cc ipfs::Client::ConfigGet
@@ -114,7 +114,7 @@ class Client {
   /** Add or replace a config knob at the peer.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/config#configset.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/CONFIG.md#configset.
    *
    * An example usage:
    * @snippet config.cc ipfs::Client::ConfigSet
@@ -131,7 +131,7 @@ class Client {
   /** Replace the entire config at the peer.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/config#configreplace.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/CONFIG.md#configreplace.
    *
    * An example usage:
    * @snippet config.cc ipfs::Client::ConfigReplace
@@ -146,7 +146,7 @@ class Client {
   /** Retrieve the peer info of a reachable node in the network.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/dht#findpeer.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/DHT.md#findpeer.
    *
    * An example usage:
    * @snippet dht.cc ipfs::Client::DhtFindPeer
@@ -163,7 +163,7 @@ class Client {
   /** Retrieve the providers for a content that is addressed by a hash.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/dht#findprovs.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/DHT.md#findprovs.
    *
    * An example usage:
    * @snippet dht.cc ipfs::Client::DhtFindProvs
@@ -180,7 +180,7 @@ class Client {
   /** Get a raw IPFS block.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/block#get.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/BLOCK.md#get.
    *
    * An example usage:
    * @snippet block.cc ipfs::Client::BlockGet
@@ -198,7 +198,7 @@ class Client {
   /** Store a raw block in IPFS.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/block#put.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/BLOCK.md#put.
    *
    * An example usage:
    * @snippet block.cc ipfs::Client::BlockPut
@@ -215,7 +215,7 @@ class Client {
   /** Get information for a raw IPFS block.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/block#stat.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/BLOCK.md#stat.
    *
    * An example usage:
    * @snippet block.cc ipfs::Client::BlockStat
@@ -232,7 +232,7 @@ class Client {
   /** Get a file from IPFS.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/files#get.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/FILES.md#get.
    *
    * An example usage:
    * @snippet files.cc ipfs::Client::FilesGet
@@ -251,7 +251,7 @@ class Client {
   /** Add files to IPFS.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/files#add.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/FILES.md#add.
    *
    * An example usage:
    * @snippet files.cc ipfs::Client::FilesAdd
@@ -313,7 +313,7 @@ class Client {
   /** Create a new MerkleDAG node.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/object#objectnew.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/OBJECT.md#objectnew.
    *
    * An example usage:
    * @snippet object.cc ipfs::Client::ObjectNew
@@ -328,7 +328,7 @@ class Client {
   /** Store a MerkleDAG node.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/object#objectput.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/OBJECT.md#objectput.
    *
    * An example usage:
    * @snippet object.cc ipfs::Client::ObjectPut
@@ -346,7 +346,7 @@ class Client {
   /** Get a MerkleDAG node.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/object#objectget.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/OBJECT.md#objectget.
    *
    * An example usage:
    * @snippet object.cc ipfs::Client::ObjectGet
@@ -365,7 +365,7 @@ class Client {
   /** Get the data field of a MerkleDAG node.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/object#objectdata.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/OBJECT.md#objectdata.
    *
    * An example usage:
    * @snippet object.cc ipfs::Client::ObjectData
@@ -382,7 +382,7 @@ class Client {
   /** Get links of a MerkleDAG node.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/object#objectlinks.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/OBJECT.md#objectlinks.
    *
    * An example usage:
    * @snippet object.cc ipfs::Client::ObjectLinks
@@ -400,7 +400,7 @@ class Client {
   /** Get stats about a MerkleDAG node.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/object#objectstat.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/OBJECT.md#objectstat.
    *
    * An example usage:
    * @snippet object.cc ipfs::Client::ObjectStat
@@ -418,7 +418,7 @@ class Client {
   /** Create a new object from an existing MerkleDAG node and add to its links.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/object#objectpatchaddlink.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/OBJECT.md#objectpatchaddlink.
    *
    * An example usage:
    * @snippet object.cc ipfs::Client::ObjectPatchAddLink
@@ -440,7 +440,7 @@ class Client {
    * links.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/object#objectpatchrmlink.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/OBJECT.md#objectpatchrmlink.
    *
    * An example usage:
    * @snippet object.cc ipfs::Client::ObjectPatchRmLink
@@ -459,7 +459,7 @@ class Client {
   /** Create a new object from an existing MerkleDAG node and append data to it.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/object#objectpatchappenddata.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/OBJECT.md#objectpatchappenddata.
    *
    * An example usage:
    * @snippet object.cc ipfs::Client::ObjectPatchAppendData
@@ -478,7 +478,7 @@ class Client {
   /** Create a new object from an existing MerkleDAG node and set its data.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/object#objectpatchsetdata.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/OBJECT.md#objectpatchsetdata.
    *
    * An example usage:
    * @snippet object.cc ipfs::Client::ObjectPatchSetData
@@ -497,7 +497,7 @@ class Client {
   /** Pin a given IPFS object.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/pin#add.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/PIN.md#add.
    *
    * An example usage:
    * @snippet pin.cc ipfs::Client::PinAdd
@@ -512,7 +512,7 @@ class Client {
   /** List all the objects pinned to local storage.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/pin#ls.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/PIN.md#ls.
    *
    * An example usage:
    * @snippet pin.cc ipfs::Client::PinLs__a
@@ -527,7 +527,7 @@ class Client {
   /** List the objects pinned under a specific hash.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/pin#ls.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/PIN.md#ls.
    *
    * An example usage:
    * @snippet pin.cc ipfs::Client::PinLs__b
@@ -552,7 +552,7 @@ class Client {
   /** Unpin an object.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/pin#rm.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/PIN.md#rm.
    *
    * An example usage:
    * @snippet pin.cc ipfs::Client::PinRm
@@ -571,7 +571,7 @@ class Client {
   /** List of known addresses of each peer connected.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/swarm#addrs.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/SWARM.md#addrs.
    *
    * An example usage:
    * @snippet swarm.cc ipfs::Client::SwarmAddrs
@@ -586,7 +586,7 @@ class Client {
   /** Open a connection to a given address.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/swarm#connect.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/SWARM.md#connect.
    *
    * An example usage:
    * @snippet swarm.cc ipfs::Client::SwarmConnect
@@ -603,7 +603,7 @@ class Client {
   /** Close a connection on a given address.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/swarm#disconnect.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/SWARM.md#disconnect.
    *
    * An example usage:
    * @snippet swarm.cc ipfs::Client::SwarmDisconnect
@@ -620,7 +620,7 @@ class Client {
   /** List the peers that we have connections with.
    *
    * Implements
-   * https://github.com/ipfs/interface-ipfs-core/tree/master/API/swarm#peers.
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/SWARM.md#peers.
    *
    * An example usage:
    * @snippet swarm.cc ipfs::Client::SwarmPeers


### PR DESCRIPTION
The location of the specs has changed; update the URLS to point
to the correct location.  This is a purely cosmetic change.